### PR TITLE
Make config a singleton

### DIFF
--- a/cipug/__init__.py
+++ b/cipug/__init__.py
@@ -34,10 +34,10 @@ def main():
         json.dump(config, sys.stdout, indent=4, cls=PosixPathEncoder)
         return
 
-    check_dependencies(config)
+    check_dependencies()
 
     if "--check-snapshots" in sys.argv:
-        checker = Snapshot_Checker(config)
+        checker = Snapshot_Checker()
         if checker.check():
             log("All required snapshots were found.")
         else:
@@ -45,10 +45,10 @@ def main():
 
     if (len(sys.argv) == 1) or ("--update" in sys.argv):
         # No arguments, default update behavior
-        prune_images(config)
-        resolver = Image_Version_Resolver(config)
+        prune_images()
+        resolver = Image_Version_Resolver()
         snapper = Snapper()
-        updater = Updater(config=config, resolver=resolver, snapper=snapper)
+        updater = Updater(resolver=resolver, snapper=snapper)
         errors = updater.update_all_services()
         if errors:
             log.error("Encountered errors during updating!", exit_code=errors)

--- a/cipug/config.py
+++ b/cipug/config.py
@@ -40,6 +40,7 @@ class Literally:
 class Config(dict):
     """Get config for cipug from environment variables. This has
     nothing to do with the .env file for compose."""
+    _instance = None
     settings_schema = {
         "VERBOSITY": (1, int),
         "SERVICES_ROOT": (unset, Path),
@@ -62,6 +63,12 @@ class Config(dict):
         "SNAPSHOTS_MAX_AGE_BTRBK": (36, float),
         "CONFIG_FILE": ("", str)
     }
+    
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super(Config, cls).__new__(cls)
+            super(Config, cls._instance).__init__(*args, **kwargs)
+        return cls._instance
 
     def _load_config_file(self):
         if self["CONFIG_FILE"] != "":

--- a/cipug/resolver.py
+++ b/cipug/resolver.py
@@ -10,10 +10,8 @@ class Image_Version_Resolver():
     hashed tag. It also caches results to not hit docker-hubs restrictive
     rate limit so quickly."""
 
-    def __init__(
-        self,
-        config: Config
-    ):
+    def __init__(self):
+        config = Config()
         self.cache_file = config["CACHE_LOCATION"]
         self.cache_duration = config["CACHE_DURATION"]
         self.cache = {}

--- a/cipug/snapshots.py
+++ b/cipug/snapshots.py
@@ -7,9 +7,9 @@ from .utils import get_services
 from .colors import colors
 
 class Snapshot_Checker:
-    def __init__(self, config: Config):
-        self.config = config
-        self.services: list[Path] = get_services(config)
+    def __init__(self):
+        self.config = Config()
+        self.services: list[Path] = get_services()
 
     def _last_snapshot_date_snapper(self, svc: Path) -> datetime | None:
         subdir = self.config["SNAPSHOTS_DIR_SNAPPER"]

--- a/cipug/updater.py
+++ b/cipug/updater.py
@@ -14,14 +14,13 @@ from . import exit_code
 class Updater():
     def __init__(
         self,
-        config: Config,
         resolver: Image_Version_Resolver,
         snapper: Snapper
     ):
-        self.config = config
+        self.config = Config()
         self.resolver = resolver
         self.snapper = snapper
-        self.services = get_services(self.config)
+        self.services = get_services()
 
     def _update_image_hashes(self, env: Env):
         for key in list(env.keys()): # Dict size will change, hence copy env.keys into a list

--- a/cipug/utils.py
+++ b/cipug/utils.py
@@ -8,7 +8,8 @@ from .config import Config
 from . import exit_code
 
 
-def get_services(config: Config) -> list[Path]:
+def get_services() -> list[Path]:
+    config = Config()
     if not config["SERVICES_ROOT"].is_dir():
         log.error(
             f"CIPUG_SERVICES_ROOT set to {config['SERVICES_ROOT']}"
@@ -61,9 +62,9 @@ def get_services(config: Config) -> list[Path]:
 
 
 
-def check_dependencies(config: Config):
+def check_dependencies():
     """Check if the required utilities can be run"""
-
+    config = Config()
     tools = ["skopeo"]
 
     if config["SERVICE_STOP_START"]:
@@ -90,7 +91,8 @@ def check_dependencies(config: Config):
             log.error(f"Could not find tool \"{tool}\", cannot proceed.", exit_code=exit_code.SYSTEM_ERROR)
 
 
-def prune_images(config: Config):
+def prune_images():
+    config = Config()
     if config["PRUNE_IMAGES"]:
         log("Pruning images..")
         ret = subprocess.run(


### PR DESCRIPTION
Good morning!

I noticed that the **config** variable is passed from function to function quite often. I did some refactoring to change the Config class to a singleton. Therefore, we do not need to pass the config, but the other files can instantiate the config when needed. 

I could not fully test it as I need to set up a test host with Btrfs first. If you have one, feel free to check it out.

**Background:**
I wanted to create a new function that would allow Skopeo to be run inside a Docker container instead of natively on the host. For this, I needed a new utilities function and wondered where to get the configurations from. This will be addressed in another PR.